### PR TITLE
Fix for request hash

### DIFF
--- a/src/Pokapi/Utility/Signature.php
+++ b/src/Pokapi/Utility/Signature.php
@@ -50,8 +50,7 @@ class Signature
      */
     public static function generateRequestHash(string $authTicket, string $request) : int
     {
-        $seed = hexdec(xxhash64($authTicket, 0x1B845238));
-        return (int)hexdec(xxhash64($request, (int)$seed));
+        $seed = (unpack("J", pack("H*", xxhash64($authTicket, 0x1B845238))))[1];
     }
 
     /**

--- a/src/Pokapi/Utility/Signature.php
+++ b/src/Pokapi/Utility/Signature.php
@@ -51,6 +51,7 @@ class Signature
     public static function generateRequestHash(string $authTicket, string $request) : int
     {
         $seed = (unpack("J", pack("H*", xxhash64($authTicket, 0x1B845238))))[1];
+        return (unpack("J", pack("H*", xxhash64($request, $seed))))[1];
     }
 
     /**


### PR DESCRIPTION
Me and Ni42 were trying to figure out why some of the requests give no map objects, and noticed that `hexdec()` sometimes gives a float as output. Unpacking the hex instead as a int64 fixes the problem.
