### PR TITLE
Updated dependencies for v0.35, adjusted names.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "nicklasw/s2-geometry-library-php": "dev-master",
         "protobuf-php/google-protobuf-proto": "dev-master",
         "pogo-php/pogoencrypt-php": "^1.0",
-        "jaspervdm/pogoprotos-php": "dev-default-packed-fields"
+        "jaspervdm/pogoprotos-php": "dev-master"
     },
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6e4c2a29879567eac79d36bdb4441abd",
-    "content-hash": "71ff0f8b9268cfc88476a3dce7927810",
+    "hash": "6f12103fd91314149e6aea9cbb48c5a0",
+    "content-hash": "7eaf8a1d4a3ad6d86ad2530cdf684785",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -180,16 +180,16 @@
         },
         {
             "name": "jaspervdm/pogoprotos-php",
-            "version": "dev-default-packed-fields",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jaspervdm/pogoprotos-php.git",
-                "reference": "e6e0bf540a16c8ddef7224300ed84d3ae51f59b4"
+                "reference": "00e98c5bfae63a6b38757dd1db9987538479c9ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jaspervdm/pogoprotos-php/zipball/e6e0bf540a16c8ddef7224300ed84d3ae51f59b4",
-                "reference": "e6e0bf540a16c8ddef7224300ed84d3ae51f59b4",
+                "url": "https://api.github.com/repos/jaspervdm/pogoprotos-php/zipball/00e98c5bfae63a6b38757dd1db9987538479c9ae",
+                "reference": "00e98c5bfae63a6b38757dd1db9987538479c9ae",
                 "shasum": ""
             },
             "require": {
@@ -225,12 +225,11 @@
             "homepage": "https://github.com/jaspervdm/pogoprotos-php",
             "keywords": [
                 "PoGo",
-                "pokemon",
                 "pokemon-go",
                 "protobuf",
                 "protos"
             ],
-            "time": "2016-08-21 22:16:28"
+            "time": "2016-08-28 20:45:37"
         },
         {
             "name": "nicklasw/s2-geometry-library-php",
@@ -238,12 +237,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/NicklasWallgren/s2-geometry-library-php.git",
-                "reference": "439506917844f812f0740fc2bf2115a9fb4450f4"
+                "reference": "803992b814d1ce8aaaccb905937e5a26d53d27ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/NicklasWallgren/s2-geometry-library-php/zipball/439506917844f812f0740fc2bf2115a9fb4450f4",
-                "reference": "439506917844f812f0740fc2bf2115a9fb4450f4",
+                "url": "https://api.github.com/repos/NicklasWallgren/s2-geometry-library-php/zipball/803992b814d1ce8aaaccb905937e5a26d53d27ce",
+                "reference": "803992b814d1ce8aaaccb905937e5a26d53d27ce",
                 "shasum": ""
             },
             "require-dev": {
@@ -257,7 +256,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "Fork - Port of s2-geometry-library-java into PHP",
-            "time": "2016-08-20 09:18:01"
+            "time": "2016-08-27 12:47:20"
         },
         {
             "name": "pogo-php/pogoencrypt-php",

--- a/src/Pokapi/Request/Position.php
+++ b/src/Pokapi/Request/Position.php
@@ -29,17 +29,24 @@ class Position
     protected $altitude = 8;
 
     /**
+     * @var float|int
+     */
+    protected $accuracy = 5;
+
+    /**
      * Position constructor.
      *
      * @param float $latitude
      * @param float $longitude
      * @param float $altitude
+     * @param float $accuracy
      */
-    public function __construct(float $latitude, float $longitude, float $altitude = 8.0)
+    public function __construct(float $latitude, float $longitude, float $altitude = 8.0, $accuracy = 5.0)
     {
         $this->latitude = $latitude;
         $this->longitude = $longitude;
         $this->altitude = $altitude;
+        $this->accuracy = $accuracy;
     }
 
     /**
@@ -73,6 +80,16 @@ class Position
     }
 
     /**
+     * Return horizontal accuracy.
+     *
+     * @return float|int
+     */
+    public function getAccuracy()
+    {
+        return $this->accuracy;
+    }
+
+    /**
      * Creates a randomized version of this approximate position
      *
      * @param float $minDistance
@@ -84,6 +101,7 @@ class Position
     {
         $newCoordinates = Geo::calculateNewCoordinates($this->latitude, $this->longitude, Random::randomFloat($minDistance, $maxDistance), rand(0,360));
         $newAltitude    = $this->altitude + round(Random::randomFloat(-2, 2), 2);
-        return new self($newCoordinates[0], $newCoordinates[1], $newAltitude);
+        $newAccuracy    = mt_rand(3, 10);
+        return new self($newCoordinates[0], $newCoordinates[1], $newAltitude, $newAccuracy);
     }
 }

--- a/src/Pokapi/Rpc/Requests/GetGymDetails.php
+++ b/src/Pokapi/Rpc/Requests/GetGymDetails.php
@@ -68,7 +68,7 @@ class GetGymDetails extends Request
         $message->setGymId($this->gymId);
         $message->setGymLatitude($this->gymLatitude);
         $message->setGymLongitude($this->gymLongitude);
-        $message->setClientVersion('0.33.0');
+        $message->setClientVersion('0.35.0');
 
         return $message;
     }


### PR DESCRIPTION
So, this has some changes for the 0.35 protobuf-php repository.
- RequestEnvelope needs Accuracy, not Altitude, so added that to Position (with a randomizer based on a range suggested by a PogoProtos commmit)
- All the SensorInfo fields got renamed. They are now named like the [position](https://developer.android.com/guide/topics/sensors/sensors_position.html) and [motion sensors](https://developer.android.com/guide/topics/sensors/sensors_motion.html) on the Android API.
- The SensorInfo class needs a rework that's still pending. I adjusted all the return values to their likely counterparts but they are probably still horribly broken.
