### PR TITLE
Fix typo and problem with pokestop details

### DIFF
--- a/src/Pokapi/API.php
+++ b/src/Pokapi/API.php
@@ -162,7 +162,7 @@ class API
     }
 
     /**
-     * Get map objets
+     * Get map objects
      *
      * @return GetMapObjectsResponse
      */

--- a/src/Pokapi/Rpc/Requests/GetPokestopDetails.php
+++ b/src/Pokapi/Rpc/Requests/GetPokestopDetails.php
@@ -57,6 +57,6 @@ class GetPokestopDetails extends Request{
      */
     public function getResponse(string $data)
     {
-        return new FortDetailsResponse();
+        return new FortDetailsResponse($data);
     }
 }


### PR DESCRIPTION
I have absolutely no idea how this could happen.

Really.
